### PR TITLE
update instructions for helm and kubectl

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,13 @@ Other scenarios to be targeted in the future:
 You can use any K8S cluster to run this project.
 If you do not have a K8S cluster at your disposal, you can quickly get a local one with [kind](https://kind.sigs.k8s.io/docs/user/quick-start/).
 
-_NOTE_: If you use a cluster with no access to external LoadBalancer (like a `kind` cluster), you may have to replace `type: LoadBalancer` by `type: ClusterIP` (or `type: NodePort`) in all `service.yaml` manifests:
+_NOTE_: If you use a cluster with no access to external LoadBalancer (like a `kind` cluster), you may have to replace `type: LoadBalancer` by `type: ClusterIP` (or `type: NodePort`) in all files declaring a service definition :
 
-
-```
+```bash
+# Update service type in all K8S manifests
 find delivery -type f -name "*.yaml" -print0 | xargs -0 sed -i 's/type: LoadBalancer/type: ClusterIP/g'
+# Update service type in all Helm values
+find delivery -type f -name "*.yaml" -print0 | xargs -0 sed -i 's/serviceType: LoadBalancer/serviceType: ClusterIP/g'
 ```
 
 ## Contributing

--- a/delivery/chart/README.md
+++ b/delivery/chart/README.md
@@ -17,6 +17,8 @@ helm install podtato-head ./delivery/chart
 
 This will install the chart in this directory with release name `podtato-head`.
 
+> NOTE: You can instruct helm to wait for the resources to be ready before marking the release as successful by adding the `--wait` option to the previous command.
+
 The installation can be customized by changing the following parameters via `--set` or a custom `values.yaml` file:
 
 | Parameter                       | Description                                                     | Default                      |
@@ -85,9 +87,11 @@ and connect through that:
 > NOTE: Find and kill the port-forward process afterwards using `ps` and `kill`.
 
 ```
-kubectl port-forward vc/podtato-main 9000:9000 &
+# Choose below the IP address of your machine you want to use to access application 
 ADDR=127.0.0.1
+# Choose below the port of your machine you want to use to access application 
 PORT=9000
+kubectl port-forward --address ${ADDR} svc/podtato-main ${PORT}:9000 &
 ```
 
 Now test the API itself with curl and/or a browser:
@@ -105,6 +109,12 @@ To update the application version, you can choose one of the following methods :
 - run `helm upgrade podtato-head ./delivery/chart --set main.tag=v0.1.1 --set leftLeg.tag=v0.1.1 ...`
 
 A new revision is then installed.
+
+> NOTE : to ensure idempotency between the first installation and the following updates, you should use the following command :
+
+```
+helm upgrade --install podtato-head ./delivery/chart
+```
 
 ## Rollback
 

--- a/delivery/kubectl/README.md
+++ b/delivery/kubectl/README.md
@@ -57,9 +57,11 @@ and connect through that:
 > NOTE: Find and kill the port-forward process afterwards using `ps` and `kill`.
 
 ```
-kubectl port-forward --namespace podtato-kubectl svc/podtato-main 9000:9000 &
+# Choose below the IP address of your machine you want to use to access application 
 ADDR=127.0.0.1
+# Choose below the port of your machine you want to use to access application 
 PORT=9000
+kubectl port-forward --namespace podtato-kubectl --address ${ADDR} svc/podtato-main ${PORT}:9000 &
 ```
 
 Now test the API itself with curl and/or a browser:


### PR DESCRIPTION
This PR aims to  :
- fix a typo in helm instructions (`vc` -> `svc`)
- allow user to choose its IP and PORT when port-forwarding (in the case of a kind cluster in a cloud instances, accessing a port-forwarded service with the IP of the instance needs the `--address` option)
- add notes about some useful options in helm instructions