### PR TITLE
Fix left-arm kustomize service

### DIFF
--- a/delivery/kustomize/base/service-left-arm.yaml
+++ b/delivery/kustomize/base/service-left-arm.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - port: 9002
+    - port: 9003
       targetPort: http
       protocol: TCP
       name: http


### PR DESCRIPTION
The left arm image was missing in the final image after a deployment from kustomize base : the reason was an error on the service port.