### PR TITLE
use 'podtato-head' as name consistently

### DIFF
--- a/delivery/chart/Chart.yaml
+++ b/delivery/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: podtato-head
 description: Deploys the podtato-head app
-version: 0.1.0
-appVersion: v0.1.0
+version: 0.2.1
+appVersion: 0.2.1

--- a/delivery/chart/templates/NOTES.txt
+++ b/delivery/chart/templates/NOTES.txt
@@ -1,4 +1,4 @@
-1. Get the application URL by running these commands:
+## Get the application URL by running these commands:
 {{- if .Values.ingress.enabled }}
 {{- range $host := .Values.ingress.hosts }}
   {{- range .paths }}
@@ -11,8 +11,8 @@
   echo http://$NODE_IP:$NODE_PORT
 {{- else if contains "LoadBalancer" .Values.entry.serviceType }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ printf "%s-%s" (include "podtato-head.fullname" .) "entry" }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ printf "%s-%s" (include "podtato-head.fullname" .) "entry" }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+           You can watch its status by running 'kubectl get --namespace {{ .Release.Namespace }} service --watch {{ printf "%s-%s" (include "podtato-head.fullname" .) "entry" }}'
+  export SERVICE_IP=$(kubectl get service --namespace {{ .Release.Namespace }} {{ printf "%s-%s" (include "podtato-head.fullname" .) "entry" }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
   echo http://$SERVICE_IP:{{ .Values.entry.servicePort }}
 {{- else if contains "ClusterIP" .Values.entry.serviceType }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/component={{ printf "%s-%s" (include "podtato-head.fullname" .) "entry" }}" -o jsonpath="{.items[0].metadata.name}")

--- a/delivery/chart/templates/deployment-entry.yaml
+++ b/delivery/chart/templates/deployment-entry.yaml
@@ -5,7 +5,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ printf "%s-%s" "podtato" $componentName }}
+  name: {{ printf "%s-%s" (include "podtato-head.fullname" .) $componentName }}
   labels:
     {{- include "podtato-head.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ printf "%s-%s" (include "podtato-head.fullname" .) $componentName }}

--- a/delivery/chart/templates/deployment-hat.yaml
+++ b/delivery/chart/templates/deployment-hat.yaml
@@ -5,7 +5,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ printf "%s-%s" "podtato" $componentName }}
+  name: {{ printf "%s-%s" (include "podtato-head.fullname" .) $componentName }}
   labels:
     {{- include "podtato-head.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ printf "%s-%s" (include "podtato-head.fullname" .) $componentName }}

--- a/delivery/chart/templates/deployment-left-arm.yaml
+++ b/delivery/chart/templates/deployment-left-arm.yaml
@@ -5,7 +5,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ printf "%s-%s" "podtato" $componentName }}
+  name: {{ printf "%s-%s" (include "podtato-head.fullname" .) $componentName }}
   labels:
     {{- include "podtato-head.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ printf "%s-%s" (include "podtato-head.fullname" .) $componentName }}

--- a/delivery/chart/templates/deployment-left-leg.yaml
+++ b/delivery/chart/templates/deployment-left-leg.yaml
@@ -5,7 +5,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ printf "%s-%s" "podtato" $componentName }}
+  name: {{ printf "%s-%s" (include "podtato-head.fullname" .) $componentName }}
   labels:
     {{- include "podtato-head.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ printf "%s-%s" (include "podtato-head.fullname" .) $componentName }}

--- a/delivery/chart/templates/deployment-right-arm.yaml
+++ b/delivery/chart/templates/deployment-right-arm.yaml
@@ -5,7 +5,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ printf "%s-%s" "podtato" $componentName }}
+  name: {{ printf "%s-%s" (include "podtato-head.fullname" .) $componentName }}
   labels:
     {{- include "podtato-head.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ printf "%s-%s" (include "podtato-head.fullname" .) $componentName }}

--- a/delivery/chart/templates/deployment-right-leg.yaml
+++ b/delivery/chart/templates/deployment-right-leg.yaml
@@ -5,7 +5,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ printf "%s-%s" "podtato" $componentName }}
+  name: {{ printf "%s-%s" (include "podtato-head.fullname" .) $componentName }}
   labels:
     {{- include "podtato-head.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ printf "%s-%s" (include "podtato-head.fullname" .) $componentName }}

--- a/delivery/chart/templates/service-entry.yaml
+++ b/delivery/chart/templates/service-entry.yaml
@@ -5,7 +5,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ printf "%s-%s" "podtato" $componentName }}
+  name: {{ printf "%s-%s" (include "podtato-head.fullname" .) $componentName }}
   labels:
     {{- include "podtato-head.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ printf "%s-%s" (include "podtato-head.fullname" .) $componentName }}

--- a/delivery/chart/templates/service-hat.yaml
+++ b/delivery/chart/templates/service-hat.yaml
@@ -5,7 +5,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ printf "%s-%s" "podtato" $componentName }}
+  name: {{ printf "%s-%s" (include "podtato-head.fullname" .) $componentName }}
   labels:
     {{- include "podtato-head.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ printf "%s-%s" (include "podtato-head.fullname" .) $componentName }}

--- a/delivery/chart/templates/service-left-arm.yaml
+++ b/delivery/chart/templates/service-left-arm.yaml
@@ -5,7 +5,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ printf "%s-%s" "podtato" $componentName }}
+  name: {{ printf "%s-%s" (include "podtato-head.fullname" .) $componentName }}
   labels:
     {{- include "podtato-head.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ printf "%s-%s" (include "podtato-head.fullname" .) $componentName }}

--- a/delivery/chart/templates/service-left-leg.yaml
+++ b/delivery/chart/templates/service-left-leg.yaml
@@ -5,7 +5,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ printf "%s-%s" "podtato" $componentName }}
+  name: {{ printf "%s-%s" (include "podtato-head.fullname" .) $componentName }}
   labels:
     {{- include "podtato-head.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ printf "%s-%s" (include "podtato-head.fullname" .) $componentName }}

--- a/delivery/chart/templates/service-right-arm.yaml
+++ b/delivery/chart/templates/service-right-arm.yaml
@@ -5,7 +5,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ printf "%s-%s" "podtato" $componentName }}
+  name: {{ printf "%s-%s" (include "podtato-head.fullname" .) $componentName }}
   labels:
     {{- include "podtato-head.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ printf "%s-%s" (include "podtato-head.fullname" .) $componentName }}

--- a/delivery/chart/templates/service-right-leg.yaml
+++ b/delivery/chart/templates/service-right-leg.yaml
@@ -5,7 +5,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ printf "%s-%s" "podtato" $componentName }}
+  name: {{ printf "%s-%s" (include "podtato-head.fullname" .) $componentName }}
   labels:
     {{- include "podtato-head.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ printf "%s-%s" (include "podtato-head.fullname" .) $componentName }}

--- a/delivery/chart/values.yaml
+++ b/delivery/chart/values.yaml
@@ -11,32 +11,32 @@ images:
 # keep ports in sync with podtato-services/main/pkg/provider.go
 entry:
   repositoryBasename: entry
-  tag: "0.1.0"
+  tag: "0.2.1"
   serviceType: LoadBalancer
   servicePort: 9000
 hat:
   repositoryBasename: hat
-  tag: "0.1.0"
+  tag: "0.2.1"
   serviceType: ClusterIP
   servicePort: 9001
 leftLeg:
   repositoryBasename: left-leg
-  tag: "0.1.0"
+  tag: "0.2.1"
   serviceType: ClusterIP
   servicePort: 9002
 leftArm:
   repositoryBasename: left-arm
-  tag: "0.1.0"
+  tag: "0.2.1"
   serviceType: ClusterIP
   servicePort: 9003
 rightLeg:
   repositoryBasename: right-leg
-  tag: "0.1.0"
+  tag: "0.2.1"
   serviceType: ClusterIP
   servicePort: 9004
 rightArm:
   repositoryBasename: right-arm
-  tag: "0.1.0"
+  tag: "0.2.1"
   serviceType: ClusterIP
   servicePort: 9005
 
@@ -64,7 +64,7 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
-# applies to podtato-main deployment only
+# applies to podtato-head-entry deployment only
 ingress:
   enabled: false
   annotations: {}

--- a/delivery/flux/test.sh
+++ b/delivery/flux/test.sh
@@ -24,7 +24,7 @@ if [[ -n "${github_token}" ]]; then
 fi
 
 # install gh
-gh_version=2.2.0
+gh_version=2.3.0
 curl -sSLO https://github.com/cli/cli/releases/download/v${gh_version}/gh_${gh_version}_linux_amd64.tar.gz
 tar -xzf gh_${gh_version}_linux_amd64.tar.gz \
     gh_${gh_version}_linux_amd64/bin/gh \
@@ -42,12 +42,11 @@ flux version --client
 flux install --version=latest
 # /end install flux CLI
 
-secret_ref_name=podtato-flux-secret
-git_source_name=podtato-flux-repo
+secret_ref_name=podtato-head-flux-secret
+git_source_name=podtato-head-flux-repo
 git_repo_url=https://github.com/${github_user}/podtato-head
-# TODO: update to main after merge
-git_source_branch=develop
-helmrelease_name=podtato-flux-release
+git_source_branch=main
+helmrelease_name=podtato-head-flux-release
 
 if [[ -n "${USE_SSH_GIT_AUTH}" ]]; then
     git_repo_url=ssh://git@github.com/${github_user}/podtato-head
@@ -89,6 +88,7 @@ flux create helmrelease ${helmrelease_name} \
     --target-namespace=${namespace} \
     --source=GitRepository/${git_source_name}.flux-system \
     --chart=./delivery/chart \
+    --release-name 'podtato-head' \
     --values="${tmp_values_file}"
 
 # do this here for when flux creates a new service account for the service
@@ -104,19 +104,19 @@ echo ""
 echo "=== await readiness of deployments..."
 parts=("entry" "hat" "left-leg" "left-arm" "right-leg" "right-arm")
 for part in "${parts[@]}"; do
-    kubectl wait --for=condition=Available --timeout=30s deployment --namespace ${namespace} podtato-${part}
+    kubectl wait --for=condition=Available --timeout=30s deployment --namespace ${namespace} podtato-head-${part}
 done
 
 # service tests
 ${root_dir}/scripts/test_services.sh ${namespace}
 
 echo ""
-echo "=== kubectl logs deployment/podtato-entry"
-kubectl logs deployment/podtato-entry
+echo "=== kubectl logs deployment/podtato-head-entry"
+kubectl logs deployment/podtato-head-entry
 
 echo ""
-echo "=== kubectl logs deployment/podtato-hat"
-kubectl logs deployment/podtato-hat
+echo "=== kubectl logs deployment/podtato-head-hat"
+kubectl logs deployment/podtato-head-hat
 
 if [[ -n "${WAIT_FOR_DELETE}" ]]; then
     echo ""

--- a/delivery/kubectl/manifest.yaml
+++ b/delivery/kubectl/manifest.yaml
@@ -7,23 +7,23 @@ metadata:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: podtato-entry
+  name: podtato-head-entry
   namespace: podtato-kubectl
   labels:
     app: podtato-head
 spec:
   selector:
     matchLabels:
-      component: podtato-entry
+      component: podtato-head-entry
   template:
     metadata:
       labels:
-        component: podtato-entry
+        component: podtato-head-entry
     spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: ghcr.io/podtato-head/entry:0.1.0
+        image: ghcr.io/podtato-head/entry:0.2.1
         imagePullPolicy: Always
         ports:
         - containerPort: 9000
@@ -34,13 +34,13 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: podtato-entry
+  name: podtato-head-entry
   namespace: podtato-kubectl
   labels:
     app: podtato-head
 spec:
   selector:
-    component: podtato-entry
+    component: podtato-head-entry
   ports:
   - name: http
     port: 9000
@@ -53,23 +53,23 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: podtato-hat
+  name: podtato-head-hat
   namespace: podtato-kubectl
   labels:
     app: podtato-head
 spec:
   selector:
     matchLabels:
-      component: podtato-hat
+      component: podtato-head-hat
   template:
     metadata:
       labels:
-        component: podtato-hat
+        component: podtato-head-hat
     spec:
       terminationGracePeriodSeconds: 5
       containers:
         - name: server
-          image:  ghcr.io/podtato-head/hat:0.1.0
+          image:  ghcr.io/podtato-head/hat:0.2.1
           imagePullPolicy: Always
           ports:
             - containerPort: 9000
@@ -80,13 +80,13 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: podtato-hat
+  name: podtato-head-hat
   namespace: podtato-kubectl
   labels:
     app: podtato-head
 spec:
   selector:
-    component: podtato-hat
+    component: podtato-head-hat
   ports:
     - name: http
       port: 9001
@@ -97,23 +97,23 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: podtato-left-leg
+  name: podtato-head-left-leg
   namespace: podtato-kubectl
   labels:
     app: podtato-head
 spec:
   selector:
     matchLabels:
-      component: podtato-left-leg
+      component: podtato-head-left-leg
   template:
     metadata:
       labels:
-        component: podtato-left-leg
+        component: podtato-head-left-leg
     spec:
       terminationGracePeriodSeconds: 5
       containers:
         - name: server
-          image:  ghcr.io/podtato-head/left-leg:0.1.0
+          image:  ghcr.io/podtato-head/left-leg:0.2.1
           imagePullPolicy: Always
           ports:
             - containerPort: 9000
@@ -124,13 +124,13 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: podtato-left-leg
+  name: podtato-head-left-leg
   namespace: podtato-kubectl
   labels:
     app: podtato-head
 spec:
   selector:
-    component: podtato-left-leg
+    component: podtato-head-left-leg
   ports:
     - name: http
       port: 9002
@@ -141,23 +141,23 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: podtato-left-arm
+  name: podtato-head-left-arm
   namespace: podtato-kubectl
   labels:
     app: podtato-head
 spec:
   selector:
     matchLabels:
-      component: podtato-left-arm
+      component: podtato-head-left-arm
   template:
     metadata:
       labels:
-        component: podtato-left-arm
+        component: podtato-head-left-arm
     spec:
       terminationGracePeriodSeconds: 5
       containers:
         - name: server
-          image:  ghcr.io/podtato-head/left-arm:0.1.0
+          image:  ghcr.io/podtato-head/left-arm:0.2.1
           imagePullPolicy: Always
           ports:
             - containerPort: 9000
@@ -168,13 +168,13 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: podtato-left-arm
+  name: podtato-head-left-arm
   namespace: podtato-kubectl
   labels:
     app: podtato-head
 spec:
   selector:
-    component: podtato-left-arm
+    component: podtato-head-left-arm
   ports:
     - name: http
       port: 9003
@@ -185,23 +185,23 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: podtato-right-leg
+  name: podtato-head-right-leg
   namespace: podtato-kubectl
   labels:
     app: podtato-head
 spec:
   selector:
     matchLabels:
-      component: podtato-right-leg
+      component: podtato-head-right-leg
   template:
     metadata:
       labels:
-        component: podtato-right-leg
+        component: podtato-head-right-leg
     spec:
       terminationGracePeriodSeconds: 5
       containers:
         - name: server
-          image:  ghcr.io/podtato-head/right-leg:0.1.0
+          image:  ghcr.io/podtato-head/right-leg:0.2.1
           imagePullPolicy: Always
           ports:
             - containerPort: 9000
@@ -212,13 +212,13 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: podtato-right-leg
+  name: podtato-head-right-leg
   namespace: podtato-kubectl
   labels:
     app: podtato-head
 spec:
   selector:
-    component: podtato-right-leg
+    component: podtato-head-right-leg
   ports:
     - name: http
       port: 9004
@@ -229,23 +229,23 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: podtato-right-arm
+  name: podtato-head-right-arm
   namespace: podtato-kubectl
   labels:
     app: podtato-head
 spec:
   selector:
     matchLabels:
-      component: podtato-right-arm
+      component: podtato-head-right-arm
   template:
     metadata:
       labels:
-        component: podtato-right-arm
+        component: podtato-head-right-arm
     spec:
       terminationGracePeriodSeconds: 5
       containers:
         - name: server
-          image:  ghcr.io/podtato-head/right-arm:0.1.0
+          image:  ghcr.io/podtato-head/right-arm:0.2.1
           imagePullPolicy: Always
           ports:
             - containerPort: 9000
@@ -256,13 +256,13 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: podtato-right-arm
+  name: podtato-head-right-arm
   namespace: podtato-kubectl
   labels:
     app: podtato-head
 spec:
   selector:
-    component: podtato-right-arm
+    component: podtato-head-right-arm
   ports:
     - name: http
       port: 9005

--- a/delivery/kubectl/test.sh
+++ b/delivery/kubectl/test.sh
@@ -39,18 +39,18 @@ echo ""
 echo "=== await readiness of deployments..."
 parts=("entry" "hat" "left-leg" "left-arm" "right-leg" "right-arm")
 for part in "${parts[@]}"; do
-    kubectl wait --for=condition=Available --timeout=30s deployment --namespace ${namespace} podtato-${part}
+    kubectl wait --for=condition=Available --timeout=30s deployment --namespace ${namespace} podtato-head-${part}
 done
 
 ${root_dir}/scripts/test_services.sh ${namespace}
 
 echo ""
-echo "=== kubectl logs deployment/podtato-entry"
-kubectl logs deployment/podtato-entry
+echo "=== kubectl logs deployment/podtato-head-entry"
+kubectl logs deployment/podtato-head-entry
 
 echo ""
-echo "=== kubectl logs deployment/podtato-hat"
-kubectl logs deployment/podtato-hat
+echo "=== kubectl logs deployment/podtato-head-hat"
+kubectl logs deployment/podtato-head-hat
 
 if [[ -n "${WAIT_FOR_DELETE}" ]]; then
     echo ""

--- a/delivery/kustomize/base/deployment-entry.yaml
+++ b/delivery/kustomize/base/deployment-entry.yaml
@@ -2,11 +2,11 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: podtato-entry
+  name: podtato-head-entry
   labels:
     app.kubernetes.io/name: podtato-head
     app.kubernetes.io/component: entry
-    app.kubernetes.io/version: '0.1.0'
+    app.kubernetes.io/version: '0.2.1'
     app.kubernetes.io/managed-by: kustomize
 spec:
   replicas: 1
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: podtato-head
       containers:
         - name: podtato-head-entry
-          image: ghcr.io/podtato-head/entry:0.1.0
+          image: ghcr.io/podtato-head/entry:0.2.1
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/delivery/kustomize/base/deployment-hat.yaml
+++ b/delivery/kustomize/base/deployment-hat.yaml
@@ -2,11 +2,11 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: podtato-hat
+  name: podtato-head-hat
   labels:
     app.kubernetes.io/name: podtato-head
     app.kubernetes.io/component: hat
-    app.kubernetes.io/version: '0.1.0'
+    app.kubernetes.io/version: '0.2.1'
     app.kubernetes.io/managed-by: kustomize
 spec:
   replicas: 1
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: podtato-head
       containers:
         - name: podtato-head-hat
-          image: ghcr.io/podtato-head/hat:0.1.0
+          image: ghcr.io/podtato-head/hat:0.2.1
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/delivery/kustomize/base/deployment-left-arm.yaml
+++ b/delivery/kustomize/base/deployment-left-arm.yaml
@@ -2,11 +2,11 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: podtato-left-arm
+  name: podtato-head-left-arm
   labels:
     app.kubernetes.io/name: podtato-head
     app.kubernetes.io/component: left-arm
-    app.kubernetes.io/version: '0.1.0'
+    app.kubernetes.io/version: '0.2.1'
     app.kubernetes.io/managed-by: kustomize
 spec:
   replicas: 1
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: podtato-head
       containers:
         - name: podtato-head-left-arm
-          image: ghcr.io/podtato-head/left-arm:0.1.0
+          image: ghcr.io/podtato-head/left-arm:0.2.1
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/delivery/kustomize/base/deployment-left-leg.yaml
+++ b/delivery/kustomize/base/deployment-left-leg.yaml
@@ -2,11 +2,11 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: podtato-left-leg
+  name: podtato-head-left-leg
   labels:
     app.kubernetes.io/name: podtato-head
     app.kubernetes.io/component: left-leg
-    app.kubernetes.io/version: '0.1.0'
+    app.kubernetes.io/version: '0.2.1'
     app.kubernetes.io/managed-by: kustomize
 spec:
   replicas: 1
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: podtato-head
       containers:
         - name: podtato-head-left-leg
-          image: ghcr.io/podtato-head/left-leg:0.1.0
+          image: ghcr.io/podtato-head/left-leg:0.2.1
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/delivery/kustomize/base/deployment-right-arm.yaml
+++ b/delivery/kustomize/base/deployment-right-arm.yaml
@@ -2,11 +2,11 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: podtato-right-arm
+  name: podtato-head-right-arm
   labels:
     app.kubernetes.io/name: podtato-head
     app.kubernetes.io/component: right-arm
-    app.kubernetes.io/version: '0.1.0'
+    app.kubernetes.io/version: '0.2.1'
     app.kubernetes.io/managed-by: kustomize
 spec:
   replicas: 1
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: podtato-head
       containers:
         - name: podtato-head-right-arm
-          image: ghcr.io/podtato-head/right-arm:0.1.0
+          image: ghcr.io/podtato-head/right-arm:0.2.1
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/delivery/kustomize/base/deployment-right-leg.yaml
+++ b/delivery/kustomize/base/deployment-right-leg.yaml
@@ -2,11 +2,11 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: podtato-right-leg
+  name: podtato-head-right-leg
   labels:
     app.kubernetes.io/name: podtato-head
     app.kubernetes.io/component: right-leg
-    app.kubernetes.io/version: '0.1.0'
+    app.kubernetes.io/version: '0.2.1'
     app.kubernetes.io/managed-by: kustomize
 spec:
   replicas: 1
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: podtato-head
       containers:
         - name: podtato-head-right-leg
-          image: ghcr.io/podtato-head/right-leg:0.1.0
+          image: ghcr.io/podtato-head/right-leg:0.2.1
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/delivery/kustomize/base/service-entry.yaml
+++ b/delivery/kustomize/base/service-entry.yaml
@@ -2,11 +2,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: podtato-entry
+  name: podtato-head-entry
   labels:
     app.kubernetes.io/name: podtato-head
     app.kubernetes.io/component: entry
-    app.kubernetes.io/version: '0.1.0'
+    app.kubernetes.io/version: '0.2.1'
     app.kubernetes.io/managed-by: kustomize
 spec:
   type: LoadBalancer

--- a/delivery/kustomize/base/service-hat.yaml
+++ b/delivery/kustomize/base/service-hat.yaml
@@ -2,11 +2,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: podtato-hat
+  name: podtato-head-hat
   labels:
     app.kubernetes.io/name: podtato-head
     app.kubernetes.io/component: hat
-    app.kubernetes.io/version: '0.1.0'
+    app.kubernetes.io/version: '0.2.1'
     app.kubernetes.io/managed-by: kustomize
 spec:
   type: ClusterIP

--- a/delivery/kustomize/base/service-left-arm.yaml
+++ b/delivery/kustomize/base/service-left-arm.yaml
@@ -2,11 +2,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: podtato-left-arm
+  name: podtato-head-left-arm
   labels:
     app.kubernetes.io/name: podtato-head
     app.kubernetes.io/component: left-arm
-    app.kubernetes.io/version: '0.1.0'
+    app.kubernetes.io/version: '0.2.1'
     app.kubernetes.io/managed-by: kustomize
 spec:
   type: ClusterIP

--- a/delivery/kustomize/base/service-left-leg.yaml
+++ b/delivery/kustomize/base/service-left-leg.yaml
@@ -2,11 +2,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: podtato-left-leg
+  name: podtato-head-left-leg
   labels:
     app.kubernetes.io/name: podtato-head
     app.kubernetes.io/component: left-leg
-    app.kubernetes.io/version: '0.1.0'
+    app.kubernetes.io/version: '0.2.1'
     app.kubernetes.io/managed-by: kustomize
 spec:
   type: ClusterIP

--- a/delivery/kustomize/base/service-right-arm.yaml
+++ b/delivery/kustomize/base/service-right-arm.yaml
@@ -2,11 +2,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: podtato-right-arm
+  name: podtato-head-right-arm
   labels:
     app.kubernetes.io/name: podtato-head
     app.kubernetes.io/component: right-arm
-    app.kubernetes.io/version: '0.1.0'
+    app.kubernetes.io/version: '0.2.1'
     app.kubernetes.io/managed-by: kustomize
 spec:
   type: ClusterIP

--- a/delivery/kustomize/base/service-right-leg.yaml
+++ b/delivery/kustomize/base/service-right-leg.yaml
@@ -2,11 +2,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: podtato-right-leg
+  name: podtato-head-right-leg
   labels:
     app.kubernetes.io/name: podtato-head
     app.kubernetes.io/component: right-leg
-    app.kubernetes.io/version: '0.1.0'
+    app.kubernetes.io/version: '0.2.1'
     app.kubernetes.io/managed-by: kustomize
 spec:
   type: ClusterIP

--- a/delivery/kustomize/base/serviceaccount.yaml
+++ b/delivery/kustomize/base/serviceaccount.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: podtato-head
     app.kubernetes.io/component: serviceaccount
-    app.kubernetes.io/version: '0.1.0'
+    app.kubernetes.io/version: '0.2.1'
     app.kubernetes.io/managed-by: kustomize
 imagePullSecrets:
   - name: ghcr

--- a/delivery/kustomize/overlay/hpa.yaml
+++ b/delivery/kustomize/overlay/hpa.yaml
@@ -1,7 +1,7 @@
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: podtato-entry-hpa
+  name: podtato-head-entry-hpa
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/delivery/kustomize/overlay/patch.yaml
+++ b/delivery/kustomize/overlay/patch.yaml
@@ -8,4 +8,4 @@ spec:
     spec:
       containers:
         - name: podtato-head-entry
-          image: ghcr.io/podtato-head/entry:0.1.0
+          image: ghcr.io/podtato-head/entry:0.2.1

--- a/delivery/kustomize/test.sh
+++ b/delivery/kustomize/test.sh
@@ -59,18 +59,18 @@ echo ""
 echo "=== await readiness of deployments..."
 parts=("entry" "hat" "left-leg" "left-arm" "right-leg" "right-arm")
 for part in "${parts[@]}"; do
-    kubectl wait --for=condition=Available --timeout=30s deployment --namespace ${namespace} podtato-${part}
+    kubectl wait --for=condition=Available --timeout=30s deployment --namespace ${namespace} podtato-head-${part}
 done
 
 ${root_dir}/scripts/test_services.sh ${namespace}
 
 echo ""
-echo "=== kubectl logs deployment/podtato-entry"
-kubectl logs deployment/podtato-entry
+echo "=== kubectl logs deployment/podtato-head-entry"
+kubectl logs deployment/podtato-head-entry
 
 echo ""
-echo "=== kubectl logs deployment/podtato-hat"
-kubectl logs deployment/podtato-hat
+echo "=== kubectl logs deployment/podtato-head-hat"
+kubectl logs deployment/podtato-head-hat
 
 if [[ -n "${WAIT_FOR_DELETE}" ]]; then
     echo ""
@@ -108,18 +108,18 @@ echo ""
 echo "=== await readiness of deployments..."
 parts=("entry" "hat" "left-leg" "left-arm" "right-leg" "right-arm")
 for part in "${parts[@]}"; do
-    kubectl wait --for=condition=Available --timeout=30s deployment --namespace ${namespace} podtato-${part}
+    kubectl wait --for=condition=Available --timeout=30s deployment --namespace ${namespace} podtato-head-${part}
 done
 
 ${root_dir}/scripts/test_services.sh ${namespace}
 
 echo ""
-echo "=== kubectl logs deployment/podtato-entry"
-kubectl logs deployment/podtato-entry
+echo "=== kubectl logs deployment/podtato-head-entry"
+kubectl logs deployment/podtato-head-entry
 
 echo ""
-echo "=== kubectl logs deployment/podtato-hat"
-kubectl logs deployment/podtato-hat
+echo "=== kubectl logs deployment/podtato-head-hat"
+kubectl logs deployment/podtato-head-hat
 
 if [[ -n "${WAIT_FOR_DELETE}" ]]; then
     echo ""

--- a/podtato-head/build/version.sh
+++ b/podtato-head/build/version.sh
@@ -1,44 +1,34 @@
 #! /usr/bin/env bash
 
-# Default to using previous version number for tests. This keeps things simple
-# cause we expect downstream examples to specify the latest version, and per
-# this new images will use existing examples for tests.
-#
-# Alternatively, to specify a custom version like `0.2.0-beta1` set a
-# global ${VERSION} variable before calling this function. You will likely need
-# to pass that same ${VERSION} variable to downstream examples to use to
-# parameterize image tags.
+# To specify a custom version set a global ${VERSION} variable before calling
+# this function. You will likely need to pass that same ${VERSION} variable to
+# downstream examples to use to parameterize image tags.
 
 # NOTE: Test images are pushed to ghcr.io/${github_user}/podtato-head/...
 #       Release images are pushed to ghcr.io/podtato-head/...
 
-# For release builds, we get the latest tag, strip it of prefixes and suffixes, and increment the _minor_ version by 1 (default).
-# If ${INCREMENT_MAJOR} or ${INCREMENT_PATCH} are set we increment those instead.
+# We get the latest tag, strip it of prefixes and suffixes, and increment the
+# patch (x.y.Z) version by 1 by default.
+# If ${INCREMENT_MAJOR} or ${INCREMENT_MINOR} are set we increment those instead.
 
 function version_to_use () {
-    # get last tagged commit
     current_release_commit=$(git --no-pager rev-list --tags --max-count=1)
     current_release_version="$(git describe --tags ${current_release_commit})"
 
-    # default to using previous version number for tests
-    if [[ -z "${RELEASE_BUILD}" ]]; then
-        version=${VERSION:-${current_release_version}}
+    bare_version=$(echo "${current_release_version}" | \
+        sed 's/^v//' | \
+        sed 's/-.*$//')
+    ver_array=($(echo "${bare_version}" | tr '.' ' '))
+    if [[ ${INCREMENT_MAJOR} ]]; then
+        ver_array[0]=$((${ver_array[0]} + 1))
+    elif [[ ${INCREMENT_MINOR} ]]; then
+        ver_array[1]=$((${ver_array[1]} + 1))
     else
-        # release build, increment version
-        bare_version=$(echo "${current_release_version}" | \
-            sed 's/^v//' | \
-            sed 's/-.*$//')
-        ver_array=($(echo "${bare_version}" | tr '.' ' '))
-        if [[ ${INCREMENT_MAJOR} ]]; then
-            ver_array[0]=$((${ver_array[0]} + 1))
-        elif [[ ${INCREMENT_PATCH} ]]; then
-            ver_array[2]=$((${ver_array[2]} + 1))
-        else
-            ver_array[1]=$((${ver_array[1]} + 1))
-        fi
-        IFS='.'
-        version=${VERSION:-$(echo "${ver_array[*]}")}
-        unset IFS
+        ver_array[2]=$((${ver_array[2]} + 1))
     fi
+    IFS='.'
+    version=${VERSION:-$(echo "${ver_array[*]}")}
+    unset IFS
+
     echo "${version}"
 }

--- a/podtato-head/pkg/services/service_discoverer.go
+++ b/podtato-head/pkg/services/service_discoverer.go
@@ -17,11 +17,11 @@ type staticServiceDiscoverer struct {
 func NewStaticServiceDiscoverer() *staticServiceDiscoverer {
 	return &staticServiceDiscoverer{
 		staticServiceMap: map[string]*url.URL{
-			"hat": mustParseURL("http://podtato-hat:9001"),
-			"left-leg": mustParseURL("http://podtato-left-leg:9002"),
-			"left-arm": mustParseURL("http://podtato-left-arm:9003"),
-			"right-leg": mustParseURL("http://podtato-right-leg:9004"),
-			"right-arm": mustParseURL("http://podtato-right-arm:9005"),
+			"hat": mustParseURL("http://podtato-head-hat:9001"),
+			"left-leg": mustParseURL("http://podtato-head-left-leg:9002"),
+			"left-arm": mustParseURL("http://podtato-head-left-arm:9003"),
+			"right-leg": mustParseURL("http://podtato-head-right-leg:9004"),
+			"right-arm": mustParseURL("http://podtato-head-right-arm:9005"),
 		},
 	}
 }

--- a/scripts/test_services.sh
+++ b/scripts/test_services.sh
@@ -7,8 +7,8 @@ target_namespace=${1:-podtato-kubectl}
 ADDR=127.0.0.1
 PORT=9000
 
-echo "INFO: forwarding port ${ADDR}:${PORT} to service/podtato-entry in namespace/${target_namespace}"
-kubectl port-forward --namespace ${target_namespace} --address ${ADDR} svc/podtato-entry ${PORT}:9000 &> /dev/null &
+echo "INFO: forwarding port ${ADDR}:${PORT} to service/podtato-head-entry in namespace/${target_namespace}"
+kubectl port-forward --namespace ${target_namespace} --address ${ADDR} service/podtato-head-entry ${PORT}:9000 &> /dev/null &
 pid=$!
 trap "kill ${pid} &> /dev/null" EXIT
 sleep 3


### PR DESCRIPTION
This fixes #125 by naming everything consistently `podtato-head-${part}`; previously some things were named `podtato-${part}`. This change effects the static service discovery implementation since the service name changes, so it depends on a fresh build of the container images.

In working on the change it became clear that it made the most sense to bump the version number _early_ for testing changes rather than using the current, existing version number. By changing the version number early, this change already includes the updated version number so that when it's merged to `main` the new tag version number will match the one in the code.

It also made sense to switch to incrementing the _patch_ number (x.y.**Z**) by default so that we don't end up with a minor bump for every commit.

Note that the flux test fails because it points to the `main` branch here, so it won't pass till this is merged to main. Previously the flux test pointed at the `develop` branch here - incorrectly.