### PR TITLE
adding ability to set deployment extra env variables for things like specifying the part number

### DIFF
--- a/delivery/chart/Chart.yaml
+++ b/delivery/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: podtato-head
 description: Deploys the podtato-head app
-version: 0.1.0
+version: 0.1.1
 appVersion: v0.1.0

--- a/delivery/chart/Chart.yaml
+++ b/delivery/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: podtato-head
 description: Deploys the podtato-head app
-version: 0.2.1
+version: 0.2.2
 appVersion: 0.2.1

--- a/delivery/chart/README.md
+++ b/delivery/chart/README.md
@@ -34,7 +34,7 @@ The installation can be customized by changing the following parameters via
 | `<service>.tag`                 | Tag of image repo for <service>                                 | `0.1.0`                      |
 | `<service>.serviceType`         | Service type for <service>                                      | `LoadBalancer` for main      |
 | `<service>.servicePort`         | Service port for <service>                                      | `9000`-`9005`                |
-| `<service>.extraEnvs`           | Add "env:" entries on Deployments (ex: PODTATO_PART_NUMBER)     | `[]`                         |
+| `<service>.env`                 | Add "env:" entries on Deployments (ex: PODTATO_PART_NUMBER)     | `[]`                         |
 | `serviceAccount.create`         | Whether or not to create dedicated service account              | `true`                       |
 | `serviceAccount.name`           | Name of the service account to use                              | `default`                    |
 | `serviceAccount.annotations`    | Annotations to add to a created service account                 | `{}`                         |

--- a/delivery/chart/README.md
+++ b/delivery/chart/README.md
@@ -34,6 +34,7 @@ The installation can be customized by changing the following parameters via
 | `<service>.tag`                 | Tag of image repo for <service>                                 | `0.1.0`                      |
 | `<service>.serviceType`         | Service type for <service>                                      | `LoadBalancer` for main      |
 | `<service>.servicePort`         | Service port for <service>                                      | `9000`-`9005`                |
+| `<service>.extraEnvs`           | Add "env:" entries on Deployments (ex: PODTATO_PART_NUMBER)     | `[]`                         |
 | `serviceAccount.create`         | Whether or not to create dedicated service account              | `true`                       |
 | `serviceAccount.name`           | Name of the service account to use                              | `default`                    |
 | `serviceAccount.annotations`    | Annotations to add to a created service account                 | `{}`                         |

--- a/delivery/chart/templates/deployment-entry.yaml
+++ b/delivery/chart/templates/deployment-entry.yaml
@@ -1,6 +1,7 @@
 {{ $componentName := "entry" }}
 {{ $repoBasename := .Values.entry.repositoryBasename }}
 {{ $repoTag := .Values.entry.tag }}
+{{ $extraEnvs := .Values.entry.extraEnvs }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -65,3 +66,11 @@ spec:
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          env:     
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          {{- if $extraEnvs }}
+            {{- toYaml $extraEnvs | nindent 12 }}
+          {{- end }}

--- a/delivery/chart/templates/deployment-entry.yaml
+++ b/delivery/chart/templates/deployment-entry.yaml
@@ -1,7 +1,7 @@
 {{ $componentName := "entry" }}
 {{ $repoBasename := .Values.entry.repositoryBasename }}
 {{ $repoTag := .Values.entry.tag }}
-{{ $extraEnvs := .Values.entry.extraEnvs }}
+{{ $env := .Values.entry.env }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -71,6 +71,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-          {{- if $extraEnvs }}
-            {{- toYaml $extraEnvs | nindent 12 }}
+          {{- if $env }}
+            {{- toYaml $env | nindent 12 }}
           {{- end }}

--- a/delivery/chart/templates/deployment-hat.yaml
+++ b/delivery/chart/templates/deployment-hat.yaml
@@ -1,6 +1,7 @@
 {{ $componentName := "hat" }}
 {{ $repoBasename := .Values.hat.repositoryBasename }}
 {{ $repoTag := .Values.hat.tag }}
+{{ $extraEnvs := .Values.hat.extraEnvs }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -65,3 +66,11 @@ spec:
           #     port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          {{- if $extraEnvs }}
+            {{- toYaml $extraEnvs | nindent 12 }}
+          {{- end }}

--- a/delivery/chart/templates/deployment-hat.yaml
+++ b/delivery/chart/templates/deployment-hat.yaml
@@ -1,7 +1,7 @@
 {{ $componentName := "hat" }}
 {{ $repoBasename := .Values.hat.repositoryBasename }}
 {{ $repoTag := .Values.hat.tag }}
-{{ $extraEnvs := .Values.hat.extraEnvs }}
+{{ $env := .Values.hat.env }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -71,6 +71,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-          {{- if $extraEnvs }}
-            {{- toYaml $extraEnvs | nindent 12 }}
+          {{- if $env }}
+            {{- toYaml $env | nindent 12 }}
           {{- end }}

--- a/delivery/chart/templates/deployment-left-arm.yaml
+++ b/delivery/chart/templates/deployment-left-arm.yaml
@@ -1,6 +1,7 @@
 {{ $componentName := "left-arm" }}
 {{ $repoBasename := .Values.leftArm.repositoryBasename }}
 {{ $repoTag := .Values.leftArm.tag }}
+{{ $extraEnvs := .Values.leftArm.extraEnvs }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -65,3 +66,11 @@ spec:
           #     port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          {{- if $extraEnvs }}
+            {{- toYaml $extraEnvs | nindent 12 }}
+          {{- end }}

--- a/delivery/chart/templates/deployment-left-arm.yaml
+++ b/delivery/chart/templates/deployment-left-arm.yaml
@@ -1,7 +1,7 @@
 {{ $componentName := "left-arm" }}
 {{ $repoBasename := .Values.leftArm.repositoryBasename }}
 {{ $repoTag := .Values.leftArm.tag }}
-{{ $extraEnvs := .Values.leftArm.extraEnvs }}
+{{ $env := .Values.leftArm.env }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -71,6 +71,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-          {{- if $extraEnvs }}
-            {{- toYaml $extraEnvs | nindent 12 }}
+          {{- if $env }}
+            {{- toYaml $env | nindent 12 }}
           {{- end }}

--- a/delivery/chart/templates/deployment-left-leg.yaml
+++ b/delivery/chart/templates/deployment-left-leg.yaml
@@ -1,7 +1,7 @@
 {{ $componentName := "left-leg" }}
 {{ $repoBasename := .Values.leftLeg.repositoryBasename }}
 {{ $repoTag := .Values.leftLeg.tag }}
-{{ $extraEnvs := .Values.leftLeg.extraEnvs }}
+{{ $env := .Values.leftLeg.env }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -71,6 +71,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-          {{- if $extraEnvs }}
-            {{- toYaml $extraEnvs | nindent 12 }}
+          {{- if $env }}
+            {{- toYaml $env | nindent 12 }}
           {{- end }}

--- a/delivery/chart/templates/deployment-left-leg.yaml
+++ b/delivery/chart/templates/deployment-left-leg.yaml
@@ -1,6 +1,7 @@
 {{ $componentName := "left-leg" }}
 {{ $repoBasename := .Values.leftLeg.repositoryBasename }}
 {{ $repoTag := .Values.leftLeg.tag }}
+{{ $extraEnvs := .Values.leftLeg.extraEnvs }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -65,3 +66,11 @@ spec:
           #     port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          env:     
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          {{- if $extraEnvs }}
+            {{- toYaml $extraEnvs | nindent 12 }}
+          {{- end }}

--- a/delivery/chart/templates/deployment-right-arm.yaml
+++ b/delivery/chart/templates/deployment-right-arm.yaml
@@ -1,7 +1,7 @@
 {{ $componentName := "right-arm" }}
 {{ $repoBasename := .Values.rightArm.repositoryBasename }}
 {{ $repoTag := .Values.rightArm.tag }}
-{{ $extraEnvs := .Values.rightArm.extraEnvs }}
+{{ $env := .Values.rightArm.env }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -71,6 +71,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-          {{- if $extraEnvs }}
-            {{- toYaml $extraEnvs | nindent 12 }}
+          {{- if $env }}
+            {{- toYaml $env | nindent 12 }}
           {{- end }}

--- a/delivery/chart/templates/deployment-right-arm.yaml
+++ b/delivery/chart/templates/deployment-right-arm.yaml
@@ -1,6 +1,7 @@
 {{ $componentName := "right-arm" }}
 {{ $repoBasename := .Values.rightArm.repositoryBasename }}
 {{ $repoTag := .Values.rightArm.tag }}
+{{ $extraEnvs := .Values.rightArm.extraEnvs }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -65,3 +66,11 @@ spec:
           #     port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          {{- if $extraEnvs }}
+            {{- toYaml $extraEnvs | nindent 12 }}
+          {{- end }}

--- a/delivery/chart/templates/deployment-right-leg.yaml
+++ b/delivery/chart/templates/deployment-right-leg.yaml
@@ -1,7 +1,7 @@
 {{ $componentName := "right-leg" }}
 {{ $repoBasename := .Values.rightLeg.repositoryBasename }}
 {{ $repoTag := .Values.rightLeg.tag }}
-{{ $extraEnvs := .Values.rightLeg.extraEnvs }}
+{{ $env := .Values.rightLeg.env }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -71,6 +71,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-          {{- if $extraEnvs }}
-            {{- toYaml $extraEnvs | nindent 12 }}
+          {{- if $env }}
+            {{- toYaml $env | nindent 12 }}
           {{- end }}

--- a/delivery/chart/templates/deployment-right-leg.yaml
+++ b/delivery/chart/templates/deployment-right-leg.yaml
@@ -1,6 +1,7 @@
 {{ $componentName := "right-leg" }}
 {{ $repoBasename := .Values.rightLeg.repositoryBasename }}
 {{ $repoTag := .Values.rightLeg.tag }}
+{{ $extraEnvs := .Values.rightLeg.extraEnvs }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -65,3 +66,11 @@ spec:
           #     port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          {{- if $extraEnvs }}
+            {{- toYaml $extraEnvs | nindent 12 }}
+          {{- end }}

--- a/delivery/chart/test.sh
+++ b/delivery/chart/test.sh
@@ -27,11 +27,11 @@ if [[ -z "${RELEASE_BUILD}" ]]; then
     # replace ghcr.io/podtato-head/body with ghcr.io/podtato-head/<github_user>/body for tests and test changing hat part number
     helm upgrade --install podtato-head ${this_dir} \
         --set "images.repositoryDirname=ghcr.io/${github_user:+${github_user}/}podtato-head" \
-        --set "hat.env=02" \
+        --set "hat.env[0].name=PODTATO_PART_NUMBER" --set "hat.env[0].value=02" \
         ${github_token:+--set "images.pullSecrets[0].name=ghcr"}
 else
     helm upgrade --install podtato-head ${this_dir} \
-        --set "hat.env=02" \
+        --set "hat.env[0].name=PODTATO_PART_NUMBER" --set "hat.env[0].value=02" \
         ${github_token:+--set "images.pullSecrets[0].name=ghcr"}
 fi
 

--- a/delivery/chart/test.sh
+++ b/delivery/chart/test.sh
@@ -24,12 +24,14 @@ if [[ -n "${github_token}" && -n "${github_user}" ]]; then
 fi
 
 if [[ -z "${RELEASE_BUILD}" ]]; then
-    # replace ghcr.io/podtato-head/body with ghcr.io/podtato-head/<github_user>/body for tests
+    # replace ghcr.io/podtato-head/body with ghcr.io/podtato-head/<github_user>/body for tests and test changing hat part number
     helm upgrade --install podtato-head ${this_dir} \
         --set "images.repositoryDirname=ghcr.io/${github_user:+${github_user}/}podtato-head" \
+        --set "hat.env=02" \
         ${github_token:+--set "images.pullSecrets[0].name=ghcr"}
 else
     helm upgrade --install podtato-head ${this_dir} \
+        --set "hat.env=02" \
         ${github_token:+--set "images.pullSecrets[0].name=ghcr"}
 fi
 

--- a/delivery/chart/values.yaml
+++ b/delivery/chart/values.yaml
@@ -14,7 +14,7 @@ entry:
   tag: "0.2.1"
   serviceType: LoadBalancer
   servicePort: 9000
-  extraEnvs: []
+  env: []
   #   - name: PODTATO_PART_NUMBER
   #     value: "01"
 hat:
@@ -22,7 +22,7 @@ hat:
   tag: "0.2.1"
   serviceType: ClusterIP
   servicePort: 9001
-  extraEnvs: []
+  env: []
   #   - name: PODTATO_PART_NUMBER
   #     value: "01"
 leftLeg:
@@ -30,7 +30,7 @@ leftLeg:
   tag: "0.2.1"
   serviceType: ClusterIP
   servicePort: 9002
-  extraEnvs: []
+  env: []
   #   - name: PODTATO_PART_NUMBER
   #     value: "01"
 leftArm:
@@ -38,7 +38,7 @@ leftArm:
   tag: "0.2.1"
   serviceType: ClusterIP
   servicePort: 9003
-  extraEnvs: []
+  env: []
   #   - name: PODTATO_PART_NUMBER
   #     value: "01"
 rightLeg:
@@ -46,7 +46,7 @@ rightLeg:
   tag: "0.2.1"
   serviceType: ClusterIP
   servicePort: 9004
-  extraEnvs: []
+  env: []
   #   - name: PODTATO_PART_NUMBER
   #     value: "01"
 rightArm:
@@ -54,7 +54,7 @@ rightArm:
   tag: "0.2.1"
   serviceType: ClusterIP
   servicePort: 9005
-  extraEnvs: []
+  env: []
   #   - name: PODTATO_PART_NUMBER
   #     value: "01"
 

--- a/delivery/chart/values.yaml
+++ b/delivery/chart/values.yaml
@@ -14,31 +14,49 @@ entry:
   tag: "0.1.0"
   serviceType: LoadBalancer
   servicePort: 9000
+  extraEnvs: []
+  #   - name: PODTATO_PART_NUMBER
+  #     value: "01"
 hat:
   repositoryBasename: hat
   tag: "0.1.0"
   serviceType: ClusterIP
   servicePort: 9001
+  extraEnvs: []
+  #   - name: PODTATO_PART_NUMBER
+  #     value: "01"
 leftLeg:
   repositoryBasename: left-leg
   tag: "0.1.0"
   serviceType: ClusterIP
   servicePort: 9002
+  extraEnvs: []
+  #   - name: PODTATO_PART_NUMBER
+  #     value: "01"
 leftArm:
   repositoryBasename: left-arm
   tag: "0.1.0"
   serviceType: ClusterIP
   servicePort: 9003
+  extraEnvs: []
+  #   - name: PODTATO_PART_NUMBER
+  #     value: "01"
 rightLeg:
   repositoryBasename: right-leg
   tag: "0.1.0"
   serviceType: ClusterIP
   servicePort: 9004
+  extraEnvs: []
+  #   - name: PODTATO_PART_NUMBER
+  #     value: "01"
 rightArm:
   repositoryBasename: right-arm
   tag: "0.1.0"
   serviceType: ClusterIP
   servicePort: 9005
+  extraEnvs: []
+  #   - name: PODTATO_PART_NUMBER
+  #     value: "01"
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
PR purpose:
In order to change the podtato part via environment variable, the helm chart has been updated to reflect 

Fixes:
https://github.com/podtato-head/podtato-head/issues/140

Other info:
Updated readme and bumped up the helm chart version in the Chart.yaml from 0.1.0 to 0.1.1