### PR TITLE
updating deploy kustomization section to allow for env to be set to change parts, also enabled basic tcp probes for services without one defined

### DIFF
--- a/delivery/kustomize/README.md
+++ b/delivery/kustomize/README.md
@@ -33,6 +33,8 @@ Look in `delivery/kustomize/overlay` for an example of an overlay which
 transforms resource for delivery to a production environment by adding labels
 and modifying image names.
 
+(OPTIONAL): Modify the kustomization.yaml to manipulate resources; for example, uncomment the patches.
+
 Render the overlay with `kustomize build ./delivery/kustomize/overlay`
 
 Apply it with `kustomize build ./delivery/kustomize/overlay | kubectl apply -f -`

--- a/delivery/kustomize/base/deployment-entry.yaml
+++ b/delivery/kustomize/base/deployment-entry.yaml
@@ -39,3 +39,8 @@ spec:
               path: /
               port: http
           resources: {}
+          env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name

--- a/delivery/kustomize/base/deployment-hat.yaml
+++ b/delivery/kustomize/base/deployment-hat.yaml
@@ -30,12 +30,15 @@ spec:
             - name: http
               containerPort: 9000
               protocol: TCP
-          # livenessProbe:
-          #   httpGet:
-          #     path: /
-          #     port: http
-          # readinessProbe:
-          #   httpGet:
-          #     path: /
-          #     port: http
+          livenessProbe:
+            tcpSocket:
+              port: http
+          readinessProbe:
+            tcpSocket:
+              port: http
           resources: {}
+          env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name

--- a/delivery/kustomize/base/deployment-left-arm.yaml
+++ b/delivery/kustomize/base/deployment-left-arm.yaml
@@ -30,12 +30,15 @@ spec:
             - name: http
               containerPort: 9000
               protocol: TCP
-          # livenessProbe:
-          #   httpGet:
-          #     path: /
-          #     port: http
-          # readinessProbe:
-          #   httpGet:
-          #     path: /
-          #     port: http
+          livenessProbe:
+            tcpSocket:
+              port: http
+          readinessProbe:
+            tcpSocket:
+              port: http
           resources: {}
+          env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name

--- a/delivery/kustomize/base/deployment-left-leg.yaml
+++ b/delivery/kustomize/base/deployment-left-leg.yaml
@@ -30,12 +30,15 @@ spec:
             - name: http
               containerPort: 9000
               protocol: TCP
-          # livenessProbe:
-          #   httpGet:
-          #     path: /
-          #     port: http
-          # readinessProbe:
-          #   httpGet:
-          #     path: /
-          #     port: http
+          livenessProbe:
+            tcpSocket:
+              port: http
+          readinessProbe:
+            tcpSocket:
+              port: http
           resources: {}
+          env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name

--- a/delivery/kustomize/base/deployment-right-arm.yaml
+++ b/delivery/kustomize/base/deployment-right-arm.yaml
@@ -30,12 +30,15 @@ spec:
             - name: http
               containerPort: 9000
               protocol: TCP
-          # livenessProbe:
-          #   httpGet:
-          #     path: /
-          #     port: http
-          # readinessProbe:
-          #   httpGet:
-          #     path: /
-          #     port: http
+          livenessProbe:
+            tcpSocket:
+              port: http
+          readinessProbe:
+            tcpSocket:
+              port: http
           resources: {}
+          env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name

--- a/delivery/kustomize/base/deployment-right-leg.yaml
+++ b/delivery/kustomize/base/deployment-right-leg.yaml
@@ -30,12 +30,15 @@ spec:
             - name: http
               containerPort: 9000
               protocol: TCP
-          # livenessProbe:
-          #   httpGet:
-          #     path: /
-          #     port: http
-          # readinessProbe:
-          #   httpGet:
-          #     path: /
-          #     port: http
+          livenessProbe:
+            tcpSocket:
+              port: http
+          readinessProbe:
+            tcpSocket:
+              port: http
           resources: {}
+          env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name

--- a/delivery/kustomize/overlay/kustomization.yaml
+++ b/delivery/kustomize/overlay/kustomization.yaml
@@ -21,3 +21,17 @@ commonLabels:
 ## kustomize transformers that operate on resources
 transformers:
   - labels.yaml
+
+## patches to be applied to target resources
+#patches:
+#  - patch: |-
+#      - op: add
+#        path: /spec/template/spec/containers/0/env/-
+#        value: 
+#            name: PODTATO_PART_NUMBER
+#            value: "02"
+#    target:
+#      group: apps
+#      version: v1
+#      kind: Deployment  #patch all deployments
+##      name: podtato-head-hat  #patch a specific named deployment


### PR DESCRIPTION
PR purpose:
In order to change the podtato part via environment variable, the kustomize delivery method has been updated to reflect

Fixes:
https://github.com/podtato-head/podtato-head/issues/140

Other info:
Updated kustomize base resources with a single env value (same as was done with the helm chart), set basic tcp probes on all parts (except entry, it already has working http probes), added an example in the overlay/kustomization.yaml on how to set part number on all deployments or a specific deployment, and updated kustomize readme