### PR TITLE
Fix repositoryDirname for ghcr.io images

### DIFF
--- a/delivery/chart/values.yaml
+++ b/delivery/chart/values.yaml
@@ -4,7 +4,7 @@ fullnameOverride: ""
 # applies to all deployments in this chart
 replicaCount: 1
 images:
-  repositoryDirname: ghcr.io/podtato-head
+  repositoryDirname: ghcr.io/podtato-head/podtato-head
   pullPolicy: IfNotPresent
   pullSecrets: []
 


### PR DESCRIPTION
When running the example like described here (https://github.com/podtato-head/podtato-head/blob/main/delivery/chart/README.md) it is not working as the image path is not like `ghcr.io/podtato-head/left-leg:0.2.1`, it is `ghcr.io/podtato-head/podtato-head/left-leg:0.2.1`

```
Events:
  Type     Reason     Age                From               Message
  ----     ------     ----               ----               -------
  Normal   Scheduled  83s                default-scheduler  Successfully assigned default/podtato-head-left-leg-cf67f6bf9-28bxn to car-deb10-12
  Warning  Failed     16s (x4 over 82s)  kubelet            Error: ImagePullBackOff
  Normal   BackOff    16s (x4 over 82s)  kubelet            Back-off pulling image "ghcr.io/podtato-head/left-leg:0.2.1"
  Normal   Pulling    3s (x4 over 82s)   kubelet            Pulling image "ghcr.io/podtato-head/left-leg:0.2.1"
  Warning  Failed     3s (x4 over 82s)   kubelet            Failed to pull image "ghcr.io/podtato-head/left-leg:0.2.1": rpc error: code = Unknown desc = failed to pull and unpack image "ghcr.io/podtato-head/left-leg:0.2.1": failed to resolve reference "ghcr.io/podtato-head/left-leg:0.2.1": failed to authorize: failed to fetch anonymous token: unexpected status: 401 Unauthorized
  Warning  Failed     3s (x4 over 82s)   kubelet            Error: ErrImagePull
```

This will fix the `values.yaml` with the correct ghcr.io path.