### PR TITLE
Issue 79: Implement Microservice example for Ketch

### DIFF
--- a/delivery/ketch/README.md
+++ b/delivery/ketch/README.md
@@ -9,7 +9,7 @@ management of applications on Kubernetes using a simple command line interface.
 ## Prerequisites
 
 - Install the ketch CLI ([official docs](https://learn.theketch.io/docs/getting-started#installing-ketch))
-- The target Kubernetes cluster must include [cert-manager](https://cert-manager.io/) and an ingress controller (Istio or Traefik)([official docs](https://learn.theketch.io/docs/getting-started#ingress-controller-cluster-issuer-and-cert-manager))
+- The target Kubernetes cluster must include [cert-manager](https://cert-manager.io/) and an ingress controller (nginx or Istio or Traefik)([official docs](https://learn.theketch.io/docs/getting-started#ingress-controller-cluster-issuer-and-cert-manager))
 - Install the ketch controller
 
 A script to prepare a fresh, generic cluster with these requirements is provided in [setup-cluster.sh](./setup-cluster.sh).
@@ -17,7 +17,9 @@ A script to prepare a fresh, generic cluster with these requirements is provided
 ## Deliver
 
 Ketch delivers an app by associating it with a _framework_ and a _buildpack
-builder_. The _framework_ describes the target environment where the app will be
+builder_ when deploying from source or docker image url when deploying using a docker image. 
+
+The _framework_ describes the target environment where the app will be
 deployed; the _buildpack builder_ determines how source is built into a runnable
 image.
 
@@ -33,8 +35,7 @@ ketch framework add framework1 \
     --namespace podtato-ketch \
     --app-quota-limit '-1' \
     --cluster-issuer selfsigned-cluster-issuer \
-    --ingress-class-name istio \
-    --ingress-type istio \
+    --ingress-type nginx \
     --ingress-service-endpoint '192.168.1.201'
 ```
 
@@ -51,6 +52,46 @@ buildpacks](https://buildpacks.io/) or can deploy a pre-built container image.
   docs](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/)).
   Reference that secret in the `ketch` command as parameter `--registry-secret`.
 - Clone this repo and run the following command, replacing registry-secret and image repo hostname as appropriate:
+
+#### Potato Head Micro-services
+
+##### Deploy Hat part
+
+```bash
+ketch app deploy hat -k dev -i ghcr.io/podtato-head/hat:latest --ketch-yaml ./delivery/ketch/ketch-hat.yaml
+```
+
+##### Deploy Left Leg part
+
+```bash
+ketch app deploy left-leg -k dev -i ghcr.io/podtato-head/left-leg:latest --ketch-yaml ./delivery/ketch/ketch-left-leg.yaml
+```
+
+##### Deploy Left Arm part
+
+```bash
+ketch app deploy left-arm -k dev -i ghcr.io/podtato-head/left-arm:latest --ketch-yaml ./delivery/ketch/ketch-left-arm.yaml
+```
+
+##### Deploy Right Leg part
+
+```bash
+ketch app deploy right-leg -k dev -i ghcr.io/podtato-head/right-leg:latest --ketch-yaml ./delivery/ketch/ketch-right-leg.yaml
+```
+
+##### Deploy Right Arm part
+
+```bash
+ketch app deploy right-arm -k dev -i ghcr.io/podtato-head/right-arm:latest --ketch-yaml ./delivery/ketch/ketch-right-arm.yaml
+```
+
+##### Deploy Entry
+
+```bash
+ketch app deploy entry -k dev -i ghcr.io/podtato-head/entry:latest --env HAT_HOST=app-hat --env LEFT_LEG_HOST=app-left-leg --env LEFT_ARM_HOST=app-left-arm --env RIGHT_ARM_HOST=app-right-arm --env RIGHT_LEG_HOST=app-right-leg
+```
+
+#### Potato Head monolith
 
 ```bash
 ketch app deploy podtato-head ${root_dir}/podtato-services/main \
@@ -112,6 +153,6 @@ ketch app remove podtato-head
 ketch app remove podtato-head-image
 ketch framework remove framework1
 
-ketch_version=0.4.0
+ketch_version=0.6.2
 kubectl delete -f https://github.com/shipa-corp/ketch/releases/download/v${ketch_version}/ketch-controller.yaml
 ```

--- a/delivery/ketch/ketch-hat.yaml
+++ b/delivery/ketch/ketch-hat.yaml
@@ -1,0 +1,8 @@
+kubernetes:
+  processes:
+    web:
+      ports:
+        - name: http
+          protocol: TCP 
+          port: 9001
+          target_port: 9000

--- a/delivery/ketch/ketch-left-arm.yaml
+++ b/delivery/ketch/ketch-left-arm.yaml
@@ -1,0 +1,8 @@
+kubernetes:
+  processes:
+    web:
+      ports:
+        - name: http
+          protocol: TCP 
+          port: 9003
+          target_port: 9000

--- a/delivery/ketch/ketch-left-leg.yaml
+++ b/delivery/ketch/ketch-left-leg.yaml
@@ -1,0 +1,8 @@
+kubernetes:
+  processes:
+    web:
+      ports:
+        - name: http
+          protocol: TCP 
+          port: 9002
+          target_port: 9000

--- a/delivery/ketch/ketch-right-arm.yaml
+++ b/delivery/ketch/ketch-right-arm.yaml
@@ -1,0 +1,8 @@
+kubernetes:
+  processes:
+    web:
+      ports:
+        - name: http
+          protocol: TCP 
+          port: 9005
+          target_port: 9000

--- a/delivery/ketch/ketch-right-leg.yaml
+++ b/delivery/ketch/ketch-right-leg.yaml
@@ -1,0 +1,8 @@
+kubernetes:
+  processes:
+    web:
+      ports:
+        - name: http
+          protocol: TCP 
+          port: 9004
+          target_port: 9000

--- a/delivery/ketch/setup-cluster.sh
+++ b/delivery/ketch/setup-cluster.sh
@@ -16,17 +16,16 @@ kubectl apply -f - <<EOF
       selfSigned: {}
 EOF
 
-## install istio
+## install nginx
 tmp_dir=$(mktemp -d)
 pushd "${tmp_dir}"
-curl -sSL https://istio.io/downloadIstio | sh -
-cp ./istio-*/bin/istioctl ./istioctl
-./istioctl version
-./istioctl install --set profile=demo --skip-confirmation
+helm upgrade --install ingress-nginx ingress-nginx \
+  --repo https://kubernetes.github.io/ingress-nginx \
+  --namespace ingress-nginx --create-namespace
 popd && rm -rf "${tmp_dir}"
 
 ## install ketch controller
-ketch_version=0.5.0
+ketch_version=0.6.2
 kubectl apply -f https://github.com/shipa-corp/ketch/releases/download/v${ketch_version}/ketch-controller.yaml
 kubectl wait --for=condition="Available" deployment ketch-controller-manager -n ketch-system
 

--- a/delivery/ketch/test.sh
+++ b/delivery/ketch/test.sh
@@ -24,45 +24,102 @@ if [[ -n "${github_token}" && -n "${github_user}" ]]; then
 fi
 
 ## get node address and port
-INGRESS_PORT=$(kubectl get services -n istio-system istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="http2")].nodePort}')
+INGRESS_PORT=$(kubectl get services -n ingress-nginx ingress-nginx-controller  -o jsonpath='{.spec.ports[?(@.name=="http")].nodePort}')
 INGRESS_HOST=$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')
 
 ## add ketch framework
-ketch framework list | grep -q framework1
+FRAMEWORK="framework1"
+ketch framework list | grep -q $FRAMEWORK
 if [[ $? != 0 ]]; then
     echo "----> ketch framework add:"
-    ketch framework add framework1 \
+    ketch framework add $FRAMEWORK \
         --namespace podtato-ketch \
         --app-quota-limit '-1' \
         --cluster-issuer selfsigned-cluster-issuer \
-        --ingress-class-name istio \
-        --ingress-type istio \
+        --ingress-class-name nginx \
+        --ingress-type nginx \
         --ingress-service-endpoint "${INGRESS_HOST}"
-    ketch framework export framework1
+    ketch framework export $FRAMEWORK
 fi
 
-## add ketch app
-## must login _locally_ for image push, _in cluster_ for image pull
-echo "----> ketch app deploy:"
-# docker login ghcr.io --username ${github_user} --password "${github_token}"
-ketch app deploy podtato-head "${root_dir}/podtato-head-server" \
-    --registry-secret ghcr \
-    --builder gcr.io/buildpacks/builder:v1 \
-    --framework framework1 \
-    --ketch-yaml ${this_dir}/ketch.yaml \
-    --image ghcr.io/${github_user}/podtato-head/ketch-main:latest \
-    --env "STATIC_DIR=/workspace/static/"
+waitForApp() {
+  local app=$1
+  echo "----> awaiting deployment available for $1..."
+  sleep 3
+  output=$(kubectl wait --for=condition=Available deployment --selector "theketch.io/app-name==$1" --timeout=60s)
+  echo "$output"
+}
+imageDeploy() {
+  local app=$1
+  local framework="${2:-$FRAMEWORK}"
+  local imageUrl="${3:-"ghcr.io/podtato-head/$1:latest"}"
+  echo "----> ketch app deploy: $app"
+  ketch app deploy "$app" \
+      --framework "$framework" \
+      --ketch-yaml "${this_dir}"/ketch-"$app".yaml \
+      --image "$imageUrl"
 
-echo "----> ketch app info:"
-ketch app info podtato-head
+  waitForApp "$app"
+}
 
-echo "----> awaiting deployment available..."
-sleep 3
-kubectl wait --for=condition=Available deployment --selector 'theketch.io/app-name==podtato-head' --timeout=60s
+if [[ "${RUN_PODATOHEAD_SERVER}" ]]; then
+  ## add ketch app
+  ## must login _locally_ for image push, _in cluster_ for image pull
+  echo "----> ketch app deploy:"
+  # docker login ghcr.io --username ${github_user} --password "${github_token}"
+  ketch app deploy podtato-head "${root_dir}/podtato-head-server" \
+      --registry-secret ghcr \
+      --builder gcr.io/buildpacks/builder:v1 \
+      --framework $FRAMEWORK \
+      --ketch-yaml ${this_dir}/ketch.yaml \
+      --image ghcr.io/${github_user}/podtato-head/ketch-main:latest \
+      --env "STATIC_DIR=/workspace/static/"
 
-## test ketch app
-INGRESS_HOSTNAME=$(ketch app info podtato-head | grep '^Address' | sed -E 's/.*https?\:\/\/(.*)$/\1/')
-echo "----> testing deployment at http://${INGRESS_HOSTNAME}:${INGRESS_PORT}/"
-curl http://${INGRESS_HOSTNAME}:${INGRESS_PORT}/
-echo ""
-# curl http://${INGRESS_HOST}:${INGRESS_PORT}/
+  echo "----> ketch app info:"
+  ketch app info podtato-head
+
+  waitForApp podtato-head
+
+  ## test ketch app
+  INGRESS_HOSTNAME=$(ketch app info podtato-head | grep '^Address' | sed -E 's/.*https?\:\/\/(.*)$/\1/')
+  echo "----> testing deployment at http://${INGRESS_HOSTNAME}:${INGRESS_PORT}/"
+  curl http://${INGRESS_HOSTNAME}:${INGRESS_PORT}/
+  echo ""
+  # curl http://${INGRESS_HOST}:${INGRESS_PORT}/
+else
+  imageDeploy hat
+  imageDeploy left-arm
+  imageDeploy left-leg
+  imageDeploy right-arm
+  imageDeploy right-leg
+
+  echo "----> ketch app deploy: entry"
+
+  # TODO: Replace with current image by official latest after this PR merges. Alternative is to
+  #       deploy using source/buildpack but not sure how we can use buildpack given how source code is
+  #       organize
+  ketch app deploy entry \
+      --framework $FRAMEWORK \
+      --ketch-yaml ${this_dir}/ketch-entry.yaml \
+      --image vivekpandey/entry:0.2.1-ketch \
+      --env HAT_HOST=app-hat \
+      --env LEFT_LEG_HOST=app-left-leg \
+      --env LEFT_ARM_HOST=app-left-arm \
+      --env RIGHT_ARM_HOST=app-right-arm \
+      --env RIGHT_LEG_HOST=app-right-leg
+
+  waitForApp entry
+
+  ## test ketch app
+  sleep 5
+  INGRESS_HOSTNAME=$(ketch app info entry | grep '^Address' | sed -E 's/.*https?\:\/\/(.*)$/\1/')
+  echo "----> testing deployment at http://${INGRESS_HOSTNAME}:${INGRESS_PORT}/"
+  response=$(curl -v http://${INGRESS_HOSTNAME}:${INGRESS_PORT}/)
+  echo $response
+  if echo "$response" | grep -q "Hello Podtato!"; then
+    echo "Success"
+  else
+    echo "Failed"
+    exit 1
+  fi
+fi

--- a/podtato-head-microservices/pkg/services/service_discoverer.go
+++ b/podtato-head-microservices/pkg/services/service_discoverer.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/url"
+	"os"
 )
 
 type ServiceDiscoverer interface {
@@ -15,13 +16,34 @@ type staticServiceDiscoverer struct {
 }
 
 func NewStaticServiceDiscoverer() *staticServiceDiscoverer {
+	hatHost, found := os.LookupEnv("HAT_HOST")
+	if !found {
+		hatHost = "podtato-head-hat"
+	}
+	leftLegHost, found := os.LookupEnv("LEFT_LEG_HOST")
+	if !found {
+		leftLegHost = "podtato-head-left-leg"
+	}
+
+	leftArmHost, found := os.LookupEnv("LEFT_ARM_HOST")
+	if !found {
+		leftArmHost = "podtato-head-left-arm"
+	}
+	rightLegHost, found := os.LookupEnv("RIGHT_LEG_HOST")
+	if !found {
+		rightLegHost = "podtato-head-right-leg"
+	}
+	rightArmHost, found := os.LookupEnv("RIGHT_ARM_HOST")
+	if !found {
+		rightArmHost = "podtato-head-right-arm"
+	}
 	return &staticServiceDiscoverer{
 		staticServiceMap: map[string]*url.URL{
-			"hat": mustParseURL("http://podtato-head-hat:9001"),
-			"left-leg": mustParseURL("http://podtato-head-left-leg:9002"),
-			"left-arm": mustParseURL("http://podtato-head-left-arm:9003"),
-			"right-leg": mustParseURL("http://podtato-head-right-leg:9004"),
-			"right-arm": mustParseURL("http://podtato-head-right-arm:9005"),
+			"hat":       mustParseURL(fmt.Sprintf("http://%s:9001", hatHost)),
+			"left-leg":  mustParseURL(fmt.Sprintf("http://%s:9002", leftLegHost)),
+			"left-arm":  mustParseURL(fmt.Sprintf("http://%s:9003", leftArmHost)),
+			"right-leg": mustParseURL(fmt.Sprintf("http://%s:9004", rightLegHost)),
+			"right-arm": mustParseURL(fmt.Sprintf("http://%s:9005", rightArmHost)),
 		},
 	}
 }


### PR DESCRIPTION
This PR 
* Updates ketch to latest 0.6.2
* Implements micro-service example for Ketch
* Replaces istio by nginx for quicker cluster setup
* Includes update to service discovery so each **part** service can be read from env variables, this is needed because ketch assigns its own service name to each deployed apps.

