### PR TITLE
feat: Add util files to Keptn delivery

### DIFF
--- a/delivery/keptn/helm-charts/helloservice/templates/_helpers.tpl
+++ b/delivery/keptn/helm-charts/helloservice/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "helloservice.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "helloservice.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "helloservice.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/delivery/keptn/helm-charts/helloservice/values.yaml
+++ b/delivery/keptn/helm-charts/helloservice/values.yaml
@@ -1,2 +1,24 @@
-image: ghcr.io/podtato-head/podtatoserver:v0.1.2
+image: ghcr.io/podtato-head/podtatoserver:v0.1.0
 replicaCount: 1
+
+service:
+  type: ClusterIP
+  port: 9000
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  path: /
+  hosts:
+    - chart-example.local
+  tls: []
+
+resources: {}
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
A few Keptn use-cases require some additional files in the Helm chart and it would be great if these were here by default when cloning the repository. Another helpful file to add would be a `rollouts.yaml` Argo file.

If you think that these files should not be added, just let me know and I will search for another solution.