### PR TITLE
Fix/helm ingress

### DIFF
--- a/delivery/chart/README.md
+++ b/delivery/chart/README.md
@@ -29,7 +29,7 @@ The installation can be customized by changing the following parameters via
 | `replicaCount`                  | Number of replicas of the container                             | `1`                          |
 | `images.repositoryDirname`      | Prefix for image repos                                          | `ghcr.io/podtato-head`       |
 | `images.pullPolicy`             | Podtato Head Container pull policy                              | `IfNotPresent`               |
-| `images.pullSecrets`            | Podtato Head Pod pull secret                                    | ``                           |
+| `images.pullSecrets`            | Podtato Head Pod pull secret                                    | `[]`                         |
 | `<service>.repositoryBasename`  | Leaf part of name of image repo for <service>                   | `entry`, `hat`, etc.         |
 | `<service>.tag`                 | Tag of image repo for <service>                                 | `0.1.0`                      |
 | `<service>.serviceType`         | Service type for <service>                                      | `LoadBalancer` for main      |
@@ -40,6 +40,7 @@ The installation can be customized by changing the following parameters via
 | `serviceAccount.annotations`    | Annotations to add to a created service account                 | `{}`                         |
 | `podAnnotations`                | Map of annotations to add to the pods                           | `{}`                         |
 | `ingress.enabled`               | Enables Ingress                                                 | `false`                      |
+| `ingress.className`             | IngressClass that will be be used (Kubernetes 1.18+)            | `""`                         |
 | `ingress.annotations`           | Ingress annotations                                             | `{}`                         |
 | `ingress.hosts`                 | Ingress accepted hostnames                                      | `[]`                         |
 | `ingress.tls`                   | Ingress TLS configuration                                       | `[]`                         |
@@ -51,8 +52,6 @@ The installation can be customized by changing the following parameters via
 | `tolerations`                   | List of node taints to tolerate                                 | `[]`                         |
 | `resources`                     | Resource requests and limits                                    | `{}`                         |
 | `nodeSelector`                  | Labels for pod assignment                                       | `{}`                         |
-| `service.type`                  | Kubernetes Service type                                         | `ClusterIP`                  |
-| `service.port`                  | The port the service will use                                   | `9000`                       |
 
 ## Test
 

--- a/delivery/chart/templates/NOTES.txt
+++ b/delivery/chart/templates/NOTES.txt
@@ -2,7 +2,7 @@
 {{- if .Values.ingress.enabled }}
 {{- range $host := .Values.ingress.hosts }}
   {{- range .paths }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
   {{- end }}
 {{- end }}
 {{- else if contains "NodePort" .Values.entry.serviceType }}

--- a/delivery/chart/templates/ingress.yaml
+++ b/delivery/chart/templates/ingress.yaml
@@ -1,7 +1,15 @@
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := include "podtato-head.fullname" . -}}
-{{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{ $componentName := "entry" }}
+{{- $fullName := printf "%s-%s" (include "podtato-head.fullname" .) $componentName -}}
+{{ $svcPort := .Values.entry.servicePort -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -16,6 +24,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}
@@ -32,10 +43,20 @@ spec:
       http:
         paths:
           {{- range .paths }}
-          - path: {{ . }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
             backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
+              {{- end }}
           {{- end }}
     {{- end }}
-  {{- end }}
+{{- end }}

--- a/delivery/chart/values.yaml
+++ b/delivery/chart/values.yaml
@@ -86,12 +86,15 @@ securityContext: {}
 # applies to podtato-head-entry deployment only
 ingress:
   enabled: false
+  className: ""
   annotations: {}
-    # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
     - host: chart-example.local
-      paths: []
+      #paths: []
+      paths: 
+        - path: /
+          pathType: ImplementationSpecific
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:


### PR DESCRIPTION
PR purpose:
Fix the helm chart ingress definition to reference the entry service as well as update it to account for recent ingress apiVersion removals.

Fixes:
https://github.com/podtato-head/podtato-head/issues/173

Other info:
Also updated the helm chart readme to reflect changes and tweak syntax in a few areas.  Here is the test I ran to validate the ingress works now (using [kind](https://kind.sigs.k8s.io/docs/user/ingress/#create-cluster) with an [nginx ingress controller](https://kind.sigs.k8s.io/docs/user/ingress/#ingress-nginx)):
```
helm upgrade --install podtato-head ./ --values - <<EOF
    entry:
      serviceType: ClusterIP
    ingress:
      enabled: true
      className: nginx
      hosts:
        - host: podtato-head.127-0-0-1.nip.io
          paths: 
            - path: /
              pathType: ImplementationSpecific
EOF
```